### PR TITLE
Move system header inclusions outside extern "C"

### DIFF
--- a/gtkknob.h
+++ b/gtkknob.h
@@ -24,13 +24,13 @@
 #ifndef __GTK_KNOB_H__
 #define __GTK_KNOB_H__
 
+#include <gtk/gtk.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #pragma once
-
-#include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 

--- a/gxtuner.h
+++ b/gxtuner.h
@@ -26,15 +26,13 @@
 #ifndef _GX_TUNER_H_
 #define _GX_TUNER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <glib-object.h>
 #include <gtk/gtk.h>
 #include <string.h> 
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 G_BEGIN_DECLS
 

--- a/paintbox.h
+++ b/paintbox.h
@@ -21,11 +21,11 @@
 #ifndef __PAINT_BOX_H__
 #define __PAINT_BOX_H__
 
+#include <gtk/gtk.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <gtk/gtk.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
GLib and GTK both include extern "C" guards in their header files, so it
is unnecessary to wrap them in an extern "C" block.

A redundant extern "C" block can be harmful, because header files might
test #ifdef __cplusplus and include C++ syntax if it is defined, even in
an otherwise C header. In particular, GLib has done this since version
2.68, in order to make macros like g_object_ref() type-safe when called
from C++ code. the result was that this project failed to compile.

Resolves: https://github.com/brummer10/gxtuner/issues/19  
Bug-Debian: https://bugs.debian.org/992246

---

Note that I have only compiled this, not tested it.