### PR TITLE
build: Target a specific GLib API version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 	NAME = gxtuner
 	LIBS = `pkg-config --libs jack gtk+-3.0 gthread-2.0 fftw3f x11` -lzita-resampler
 	CFLAGS += -Wall -ffast-math `pkg-config --cflags jack gtk+-3.0 gthread-2.0 fftw3f`
+	CFLAGS += -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_54
+	CFLAGS += -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_54
 	OBJS = resources.o jacktuner.o gxtuner.o cmdparser.o gx_pitch_tracker.o gtkknob.o \
            paintbox.o tuner.o deskpager.o main.o
 	DEBNAME = $(NAME)_$(VER)


### PR DESCRIPTION
Setting GLIB_VERSION_MIN_REQUIRED selects the minimum required version
of GLib for this project. Code that was deprecated after that version
will not cause deprecation warnings, and where header files have changed
their compile-time behaviour over time, the behaviour that was seen in
the selected version will be used where possible.

Setting GLIB_VERSION_MAX_ALLOWED causes GLib to emit warnings if a
function introduced after the selected version is used.

In particular, this disables new C++ behaviour introduced in GLib 2.68,
which caused this project to fail to build.

GLib 2.54 is an arbitrary choice: it happens to be the version that was
the current stable release when gxtuner 3.0.0 was released. It could
be reduced if gxtuner needs to compile on older distributions, or
increased if a newer dependency is acceptable.

Resolves: https://github.com/brummer10/gxtuner/issues/19  
Bug-Debian: https://bugs.debian.org/992246

---

Note that I have only compiled this, not tested it.

To fix #19 you could choose to do either this, or #20, or both.